### PR TITLE
fix: make Docker builds resolve dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
   NODE_ENV=production \
   SKIP_TYPECHECK=1
 
-COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
 COPY . .
 
@@ -119,10 +118,12 @@ ENV DATABASE_URL=$DATABASE_URL \
   NEXT_PUBLIC_ADSENSE_HOME_SLOT_ID=$NEXT_PUBLIC_ADSENSE_HOME_SLOT_ID \
   NEXT_PUBLIC_ADSENSE_CHAT_SLOT_ID=$NEXT_PUBLIC_ADSENSE_CHAT_SLOT_ID
 
+# Mount dependencies from the install stage instead of copying thousands of
+# files into the Node builder. This avoids a slow 40+ second node_modules COPY;
+# the mount is available for the build and is not copied into the runtime image.
 # Persist Turbopack's filesystem cache across Dokploy deploys on this host.
-# `COPY . .` busts the layer cache every push; this mount is what makes
-# subsequent compiles incremental.
-RUN --mount=type=cache,id=deni-ai-next,target=/app/.next/cache \
+RUN --mount=type=bind,from=deps,source=/app/node_modules,target=/app/node_modules \
+  --mount=type=cache,id=deni-ai-next,target=/app/.next/cache \
   node ./node_modules/next/dist/bin/next build
 
 # Temporary disabled (runtime is now bun)

--- a/SETUP.md
+++ b/SETUP.md
@@ -298,6 +298,7 @@ A multi-stage `Dockerfile` is included for self-hosting (e.g. Dokploy):
 
 - **Install:** Bun (`bun.lock`)
 - **Build:** Node 22 runs `next build` (standalone output). Typecheck is skipped in the image (`SKIP_TYPECHECK=1`) so tsc does not fight Turbopack on small VPS CPUs — run `bun run typecheck` locally or in CI.
+- The Node builder mounts the Bun-installed dependencies from the install stage instead of copying `node_modules`, avoiding a large per-deploy file copy.
 - **Run:** Bun serves `.next/standalone` on port **3000**
 - Turbopack's `.next/cache` is stored in a BuildKit cache mount, so later deploys on the **same Dokploy host** compile incrementally. Do not enable “disable cache” / `--no-cache` in the service settings.
 - `NEXT_PUBLIC_*` values must be present at **build time** (inlined into the client bundle)

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,8 @@
         "@openrouter/ai-sdk-provider": "^3.0.0",
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.1.0",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/math": "^1.0.2",
         "@streamdown/mermaid": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.1.0",
+    "@shikijs/langs": "4.4.3",
+    "@shikijs/themes": "4.4.3",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",


### PR DESCRIPTION
## Summary\n- declare @shikijs/langs and @shikijs/themes as direct 4.4.3 dependencies for clean Docker installs\n- mount deps-stage node_modules into the Node builder instead of copying it, removing the slow 40+ second copy step\n- document the dependency mount in SETUP.md\n\n## Verification\n- bun install --frozen-lockfile\n- bun run lint\n- bun run typecheck\n- direct @shikijs/* resolution check\n- SKIP_TYPECHECK=1 bun run build (81 routes)\n\nDocker CLI is unavailable locally; the Dokploy log is the target failure being fixed.