### PR TITLE
chore: promote GPT-6 Astra to master

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -125,6 +125,18 @@ export function formatModelDeprecationDate(date: string, locale: string): string
 
 export const models: readonly ModelDefinition[] = [
   {
+    name: "GPT-6 Astra",
+    value: "gpt-6-astra",
+    author: "openai",
+    description: "OpenAI flagship for complex reasoning, coding, and agentic work.",
+    premium: true,
+    featured: true,
+    features: ["smartest", "reasoning", "coding", "smart"],
+    efforts: ["low", "medium", "high", "max"],
+    contextWindow: 1_000_000,
+    tokenMultiplier: 3,
+  },
+  {
     name: "GPT-5.6 Sol",
     value: "gpt-5.6-sol",
     author: "openai",


### PR DESCRIPTION
Promote GPT-6 Astra to master.\n\nIncluded:\n- add GPT-6 Astra to the OpenAI model catalog\n- mark it as premium with the same 3x token multiplier as Claude Fable 5\n- expose it as a featured 1M-context reasoning/coding model\n\nSource PR: #281