### PR TITLE
fix: bundle server dependencies for standalone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,11 +131,10 @@ Default branch for day-to-day work is **`canary`**. **`master`** is the promotio
 
 When the user asks to commit / push / PR / merge (including phrasing like 「全commit & push & pr & instant merge」):
 
-1. **Work branch → `canary`**
-   - Create a feature/fix branch from up-to-date `canary`.
-   - Commit scoped changes (conventional commits).
-   - Push the branch and open a PR with **base = `canary`**.
-   - If the user asked to merge (or "instant merge"), merge that PR into `canary` (delete the head branch when appropriate) and pull `canary` locally.
+1. **Directly on `canary`**
+   - Do not create a feature/fix branch or a PR into `canary` unless the user explicitly requests one.
+   - Update the local `canary` from its remote, then commit scoped changes there using a conventional commit message.
+   - Push `canary` directly to `origin/canary`.
 2. **`canary` → `master` (required promotion step)**
    - After landing work on `canary`, **always open a PR with base = `master` and head = `canary`** to promote.
    - If the user asked to merge / instant merge, merge that PR into `master` as well (do not leave promotion only on `canary`).

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,8 +18,17 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: skipTypecheck,
   },
-  // Leave large Node-only SDKs unbundled; Next already treats `shiki` as external.
-  serverExternalPackages: ["stripe", "drizzle-orm", "@neondatabase/serverless", "cheerio"],
+  // Keep server dependencies inside the standalone bundle. Bun's isolated
+  // virtual store can otherwise leave Turbopack external aliases unresolved
+  // after the standalone output is copied into the runtime image.
+  transpilePackages: [
+    "stripe",
+    "drizzle-orm",
+    "@neondatabase/serverless",
+    "cheerio",
+    "shiki",
+    "prettier",
+  ],
   // Tree-shake large icon/date packages more aggressively
   experimental: {
     optimizePackageImports: [


### PR DESCRIPTION
## Summary
- bundle Stripe and other server dependencies into the standalone output
- avoid unresolved Turbopack external aliases with Bun's virtual store
- document the direct canary workflow in AGENTS.md

## Verification
- bun run format
- bun run lint
- bun run typecheck
- bun run build
- confirmed the standalone server chunks no longer contain the stripe-fcde02642fa653bd external import